### PR TITLE
Included support for inline export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "dtsbundler-webpack-plugin",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz",
+      "integrity": "sha1-tHXW4N/wv1DyluXKbvn7tccyDx4=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Generates a single module declaration file from separate generated declaration files from an EXTERNAL module",
   "main": "plugin.js",
   "scripts": {
+    "start": "npm run build",
     "build": "tsc"
   },
   "keywords": [

--- a/plugin.js
+++ b/plugin.js
@@ -38,7 +38,7 @@ var DtsBundlerPlugin = (function () {
         var declarations = '';
         for (var fileName in declarationFiles) {
             var declarationFile = declarationFiles[fileName];
-            var data = declarationFile._value;
+            var data = declarationFile.source();
             var lines = data.split('\n');
             var i = lines.length;
             while (i--) {

--- a/plugin.js
+++ b/plugin.js
@@ -69,7 +69,7 @@ var DtsBundlerPlugin = (function () {
             }
             declarations += lines.join('\n') + '\n\n';
         }
-        return "\n      declare module " + this.moduleName + " {\n        " + declarations + "\n      }\n      export default " + this.moduleName + ";\n      ";
+        return "declare module " + this.moduleName + "\n{\n" + declarations + "}\nexport default " + this.moduleName + ";";
     };
     return DtsBundlerPlugin;
 }());

--- a/plugin.js
+++ b/plugin.js
@@ -1,10 +1,12 @@
-var DeclarationBundlerPlugin = (function () {
-    function DeclarationBundlerPlugin(options) {
+"use strict";
+var DtsBundlerPlugin = (function () {
+    function DtsBundlerPlugin(options) {
         if (options === void 0) { options = {}; }
-        this.out = options.out ? options.out : './build/';
+        this.out = options.out || './build/';
         this.excludedReferences = options.excludedReferences ? options.excludedReferences : undefined;
+        this.moduleName = options.moduleName || 'Lib';
     }
-    DeclarationBundlerPlugin.prototype.apply = function (compiler) {
+    DtsBundlerPlugin.prototype.apply = function (compiler) {
         var _this = this;
         //when the compiler is ready to emit files
         compiler.plugin('emit', function (compilation, callback) {
@@ -32,33 +34,40 @@ var DeclarationBundlerPlugin = (function () {
             callback();
         });
     };
-    DeclarationBundlerPlugin.prototype.generateCombinedDeclaration = function (declarationFiles) {
+    DtsBundlerPlugin.prototype.generateCombinedDeclaration = function (declarationFiles) {
         var declarations = '';
         for (var fileName in declarationFiles) {
             var declarationFile = declarationFiles[fileName];
-            var data = declarationFile.source();
-            var lines = data.split("\n");
+            var data = declarationFile._value;
+            var lines = data.split('\n');
             var i = lines.length;
             while (i--) {
                 var line = lines[i];
                 //exclude empty lines
-                var excludeLine = line == "";
+                var excludeLine = line == '';
                 //exclude export statements
-                excludeLine = excludeLine || line.indexOf("export") !== -1;
+                excludeLine = excludeLine || /export\s+({)|(default)/.test(line);
+                // leave a line with inline export but remove export keyword
+                if (!excludeLine) {
+                    lines[i] = lines[i].replace(/export\s/, '');
+                    lines[i] = lines[i].replace(/declare\s/, '');
+                    line = lines[i];
+                }
                 //exclude import statements
-                excludeLine = excludeLine || line.indexOf("import") !== -1;
+                excludeLine = excludeLine || line.indexOf('import') !== -1;
                 //if defined, check for excluded references
-                if (!excludeLine && this.excludedReferences && line.indexOf("<reference") !== -1) {
+                if (!excludeLine && this.excludedReferences && line.indexOf('<reference') !== -1) {
                     excludeLine = this.excludedReferences.some(function (reference) { return line.indexOf(reference) !== -1; });
                 }
                 if (excludeLine) {
                     lines.splice(i, 1);
                 }
             }
-            declarations += lines.join("\n") + "\n\n";
+            declarations += lines.join('\n') + '\n\n';
         }
-        return declarations;
+        var output = 'declare module ' + this.moduleName + '\n{\n' + declarations + '}';
+        return output;
     };
-    return DeclarationBundlerPlugin;
-})();
-module.exports = DeclarationBundlerPlugin;
+    return DtsBundlerPlugin;
+}());
+module.exports = DtsBundlerPlugin;

--- a/plugin.js
+++ b/plugin.js
@@ -62,11 +62,14 @@ var DtsBundlerPlugin = (function () {
                 if (excludeLine) {
                     lines.splice(i, 1);
                 }
+                else {
+                    // Adding internal module indentation
+                    lines[i] = '  ' + lines[i];
+                }
             }
             declarations += lines.join('\n') + '\n\n';
         }
-        var output = 'declare module ' + this.moduleName + '\n{\n' + declarations + '}';
-        return output;
+        return "declare module " + this.moduleName + "\n{\n" + declarations + "}";
     };
     return DtsBundlerPlugin;
 }());

--- a/plugin.js
+++ b/plugin.js
@@ -69,7 +69,7 @@ var DtsBundlerPlugin = (function () {
             }
             declarations += lines.join('\n') + '\n\n';
         }
-        return "declare module " + this.moduleName + "\n{\n" + declarations + "}";
+        return "\n      declare module " + this.moduleName + " {\n        " + declarations + "\n      }\n      export default " + this.moduleName + ";\n      ";
     };
     return DtsBundlerPlugin;
 }());

--- a/plugin.js
+++ b/plugin.js
@@ -46,9 +46,9 @@ var DtsBundlerPlugin = (function () {
                 //exclude empty lines
                 var excludeLine = line == '';
                 //exclude export statements
-                excludeLine = excludeLine || /export\s+({)|(default)/.test(line);
+                excludeLine = excludeLine || (/export\s+({)|(default)/.test(line) && fileName !== 'main.d.ts');
                 // leave a line with inline export but remove export keyword
-                if (!excludeLine) {
+                if (!excludeLine && fileName !== 'main.d.ts') {
                     lines[i] = lines[i].replace(/export\s/, '');
                     lines[i] = lines[i].replace(/declare\s/, '');
                     line = lines[i];

--- a/plugin.js
+++ b/plugin.js
@@ -69,7 +69,7 @@ var DtsBundlerPlugin = (function () {
             }
             declarations += lines.join('\n') + '\n\n';
         }
-        return "declare module " + this.moduleName + "\n{\n" + declarations + "}\nexport default " + this.moduleName + ";";
+        return declarations;
     };
     return DtsBundlerPlugin;
 }());

--- a/plugin.ts
+++ b/plugin.ts
@@ -84,7 +84,12 @@ class DtsBundlerPlugin {
       declarations += lines.join('\n') + '\n\n';
     }
 
-    return `declare module ${this.moduleName}\n{\n${declarations}}`;
+    return `
+      declare module ${this.moduleName} {
+        ${declarations}
+      }
+      export default ${this.moduleName};
+      `;
   }
 
 }

--- a/plugin.ts
+++ b/plugin.ts
@@ -44,7 +44,7 @@ class DtsBundlerPlugin {
     var declarations = '';
     for (var fileName in declarationFiles) {
       var declarationFile = declarationFiles[fileName];
-      var data = declarationFile._value;
+      var data = declarationFile.source();
 
       var lines = data.split('\n');
       var i = lines.length;

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,89 +1,88 @@
-class DtsBundlerPlugin
-{
-	out:string;
-	moduleName:string;
-	mode:string;
+class DtsBundlerPlugin {
+  out: string;
+  moduleName: string;
+  excludedReferences: any[];
 
-	constructor(options:any={})
-	{
-		this.out = options.out ? options.out : './build/';
-		this.excludedReferences = options.excludedReferences ? options.excludedReferences : undefined;
-	}
+  constructor(options: any = {}) {
+    this.out = options.out || './build/';
+    this.excludedReferences = options.excludedReferences ? options.excludedReferences : undefined;
+    this.moduleName = options.moduleName || 'Lib';
+  }
 
-	apply(compiler)
-	{
-		//when the compiler is ready to emit files
-		compiler.plugin('emit', (compilation,callback) =>
-		{
-			//collect all generated declaration files
-			//and remove them from the assets that will be emited
-			var declarationFiles = {};
-			for (var filename in compilation.assets)
-			{
-				if(filename.indexOf('.d.ts') !== -1)
-				{
-					declarationFiles[filename] = compilation.assets[filename];
-					delete compilation.assets[filename];
-				}
-			}
+  apply(compiler) {
+    //when the compiler is ready to emit files
+    compiler.plugin('emit', (compilation, callback) => {
+      //collect all generated declaration files
+      //and remove them from the assets that will be emited
+      var declarationFiles = {};
+      for (var filename in compilation.assets) {
+        if (filename.indexOf('.d.ts') !== -1) {
+          declarationFiles[filename] = compilation.assets[filename];
+          delete compilation.assets[filename];
+        }
+      }
 
-			//combine them into one declaration file
-			var combinedDeclaration = this.generateCombinedDeclaration(declarationFiles);
+      //combine them into one declaration file
+      var combinedDeclaration = this.generateCombinedDeclaration(declarationFiles);
 
-			//and insert that back into the assets
-			compilation.assets[this.out] = {
-				source: function() {
-					return combinedDeclaration;
-				},
-				size: function() {
-					return combinedDeclaration.length;
-				}
-			};
+      //and insert that back into the assets
+      compilation.assets[this.out] = {
+        source: function () {
+          return combinedDeclaration;
+        },
+        size: function () {
+          return combinedDeclaration.length;
+        }
+      };
 
-			//webpack may continue now
-			callback();
-		});
-	}
+      //webpack may continue now
+      callback();
+    });
+  }
 
-	private generateCombinedDeclaration(declarationFiles:Object):string
-	{
-		var declarations = '';
-		for(var fileName in declarationFiles)
-		{
-			var declarationFile = declarationFiles[fileName];
-			var data = declarationFile._value;
+  private generateCombinedDeclaration(declarationFiles: Object): string {
+    var declarations = '';
+    for (var fileName in declarationFiles) {
+      var declarationFile = declarationFiles[fileName];
+      var data = declarationFile._value;
 
-			var lines = data.split("\n");
-			var i = lines.length;
+      var lines = data.split('\n');
+      var i = lines.length;
 
 
-			while (i--)
-			{
-				var line = lines[i];
-				
-				//exclude empty lines
-				var excludeLine = line == "";
-				
-				//exclude export statements
-				excludeLine = excludeLine || line.indexOf("export") !== -1;
-				
-				//exclude import statements
-				excludeLine = excludeLine || line.indexOf("import") !== -1;
-				
-				//if defined, check for excluded references
-				if (!excludeLine && this.excludedReferences && line.indexOf("<reference") !== -1) {
-					excludeLine = this.excludedReferences.some(reference => line.indexOf(reference) !== -1);
-				}
-				if (excludeLine) {
-					lines.splice(i, 1);
-				}
-			}
-			declarations += lines.join("\n") + "\n\n";
-		}
+      while (i--) {
+        var line = lines[i];
 
-		var output = "declare module "+this.moduleName+"\n{\n" + declarations + "}";
-		return output;
-	}
+        //exclude empty lines
+        var excludeLine = line == '';
+
+        //exclude export statements
+        excludeLine = excludeLine || /export\s+({)|(default)/.test(line);
+
+        // leave a line with inline export but remove export keyword
+        if (!excludeLine) {
+          lines[i] = lines[i].replace(/export\s/, '');
+          lines[i] = lines[i].replace(/declare\s/, '');
+          line = lines[i];
+        }
+
+        //exclude import statements
+        excludeLine = excludeLine || line.indexOf('import') !== -1;
+
+        //if defined, check for excluded references
+        if (!excludeLine && this.excludedReferences && line.indexOf('<reference') !== -1) {
+          excludeLine = this.excludedReferences.some(reference => line.indexOf(reference) !== -1);
+        }
+        if (excludeLine) {
+          lines.splice(i, 1);
+        }
+      }
+      declarations += lines.join('\n') + '\n\n';
+    }
+
+    var output = 'declare module ' + this.moduleName + '\n{\n' + declarations + '}';
+    return output;
+  }
 
 }
 

--- a/plugin.ts
+++ b/plugin.ts
@@ -84,12 +84,7 @@ class DtsBundlerPlugin {
       declarations += lines.join('\n') + '\n\n';
     }
 
-    return `
-      declare module ${this.moduleName} {
-        ${declarations}
-      }
-      export default ${this.moduleName};
-      `;
+    return `declare module ${this.moduleName}\n{\n${declarations}}\nexport default ${this.moduleName};`;
   }
 
 }

--- a/plugin.ts
+++ b/plugin.ts
@@ -42,6 +42,7 @@ class DtsBundlerPlugin {
 
   private generateCombinedDeclaration(declarationFiles: Object): string {
     var declarations = '';
+
     for (var fileName in declarationFiles) {
       var declarationFile = declarationFiles[fileName];
       var data = declarationFile.source();
@@ -57,10 +58,10 @@ class DtsBundlerPlugin {
         var excludeLine = line == '';
 
         //exclude export statements
-        excludeLine = excludeLine || /export\s+({)|(default)/.test(line);
+        excludeLine = excludeLine || (/export\s+({)|(default)/.test(line) && fileName !== 'main.d.ts');
 
         // leave a line with inline export but remove export keyword
-        if (!excludeLine) {
+        if (!excludeLine && fileName !== 'main.d.ts') {
           lines[i] = lines[i].replace(/export\s/, '');
           lines[i] = lines[i].replace(/declare\s/, '');
           line = lines[i];

--- a/plugin.ts
+++ b/plugin.ts
@@ -76,12 +76,15 @@ class DtsBundlerPlugin {
         if (excludeLine) {
           lines.splice(i, 1);
         }
+        else {
+          // Adding internal module indentation
+          lines[i] = '  ' + lines[i];
+        }
       }
       declarations += lines.join('\n') + '\n\n';
     }
 
-    var output = 'declare module ' + this.moduleName + '\n{\n' + declarations + '}';
-    return output;
+    return `declare module ${this.moduleName}\n{\n${declarations}}`;
   }
 
 }

--- a/plugin.ts
+++ b/plugin.ts
@@ -85,7 +85,7 @@ class DtsBundlerPlugin {
       declarations += lines.join('\n') + '\n\n';
     }
 
-    return `declare module ${this.moduleName}\n{\n${declarations}}\nexport default ${this.moduleName};`;
+    return declarations;
   }
 
 }


### PR DESCRIPTION
The key point is to be able to do such things without worrying to lost them:
```
export class Foo {
  constructor() {}
  ...
}
```

Sorry about auto formatting the code